### PR TITLE
Fix naming in package.json for new npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Interface.js builder",
+  "name": "Interface.jsBuilder",
   "main": "index.html",
   "window": {
     "toolbar":false


### PR DESCRIPTION
NPM (newest version) complains about spaces in the "name" field in package.json. Removing the space fixes this error.
