### PR TITLE
Include Dependencies in Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,13 @@
 {
-  "name": "Interface.js builder",
+  "name": "Interface.jsBuilder",
   "main": "index.html",
   "window": {
     "toolbar":false
+  },
+  "dependencies": {
+    "midi": "*",
+    "omgosc": "*",
+    "ws": "*",
+    "connect": "*"
   }
 }


### PR DESCRIPTION
By including dependencies in Package.json, the end user only needs to say "npm install" instead of running npm install on four separate packages.
